### PR TITLE
Corrected JSON.stringify issue

### DIFF
--- a/generators/app/templates/package.template
+++ b/generators/app/templates/package.template
@@ -1,8 +1,8 @@
 {
-  "name": "<%- projectName %>",
+  "name": <%- projectName %>,
   "version": "1.0.0",
   "private": true,
-  "description": "<%- projectDescription %>",
+  "description": <%- projectDescription %>,
   "main": "index.js",
   "scripts": {
     "postInstall": "gulp build",


### PR DESCRIPTION
JSON.stringify adds the enclosing double quotes in the resulting string, which conflicted with the package template.