### PR TITLE
Made test option use JSON.stringify

### DIFF
--- a/generators/app/index.js
+++ b/generators/app/index.js
@@ -86,7 +86,7 @@ module.exports = generators.Base.extend({
     const values = {
       projectName: JSON.stringify(this.userInput.projectName),
       projectDescription: JSON.stringify(this.userInput.projectDescription),
-      projectScriptTest: 'echo \\"Error: no test specified\\" && exit 1',
+      projectScriptTest: JSON.stringify('echo "Error: no test specified" && exit 1'),
       projectDependencies: ['"gulp": "^3.9.0"'],
       projectDevDependencies: [],
       gulpHeaders: [],

--- a/generators/app/templates/package.template
+++ b/generators/app/templates/package.template
@@ -6,7 +6,7 @@
   "main": "index.js",
   "scripts": {
     "postInstall": "gulp build",
-    "test": "<%- projectScriptTest %>",
+    "test": <%- projectScriptTest %>,
     "build": "gulp build",
     "watch": "gulp watch"
   },


### PR DESCRIPTION
When populating the "test" option in the package.json file, the code now uses JSON.stringify rather than escaping a string manually.